### PR TITLE
Add ability to set secrets, mode, and ownership

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+result
+**/result/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # substitute-vars
 
-A reusable Nix flake that provides a `substituteVars` function for `${var}`-style template substitution, similar to `pkgs.substituteAll`. Unlike `substituteAll`, it uses the varible-replacement format of `${var}` rather than `@var@`.
+A reusable Nix flake that provides a `substituteVars` function for `${var}`-style template substitution, similar to `pkgs.substituteAll`.
+
+Unlike `substituteAll`, it allows the optional setting of file permissions, owner, and group, and also uses the varible-replacement format of `${var}` rather than `@var@`.
 
 ## How to Import
 
@@ -23,6 +25,9 @@ substituteVars {
     name = "Ada";
     city = "Paris";
   };
+  mode = "0755";        # optional
+  owner = "root";       # optional
+  group = "wheel";      # optional
 }
 ```
 
@@ -33,6 +38,15 @@ Run tests with:
 ```bash
 nix flake check
 ```
+
+## Security
+
+If custom permissions or ownership are used, a copy of the file will still also be present in the Nix store with world-readable permissions, so this should not be used as a way to limit visibility of the file. This is true for all Nix functions that allow setting permissions. For files that should be kept private try something like [agenix](https://github.com/ryantm/agenix) or [sops-nix](https://github.com/Mic92/sops-nix).
+
+## Notes
+
+- In sandboxed builds, `owner` and `group` will be skipped if they can't be applied.
+- File `mode` is always respected.
 
 ## License
 

--- a/flake.lock
+++ b/flake.lock
@@ -2,7 +2,9 @@
   "nodes": {
     "flake-utils": {
       "inputs": {
-        "systems": "systems"
+        "systems": [
+          "systems"
+        ]
       },
       "locked": {
         "lastModified": 1731533236,
@@ -36,21 +38,22 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
       }
     },
     "systems": {
       "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "lastModified": 1689347949,
+        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
         "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "repo": "default-linux",
+        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
         "type": "github"
       },
       "original": {
         "owner": "nix-systems",
-        "repo": "default",
+        "repo": "default-linux",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,9 +1,13 @@
 {
-  description = "Reusable substituteVars library flake";
+  description = "Reusable substituteVars library flake with sandbox-safe permissions";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs";
     flake-utils.url = "github:numtide/flake-utils";
+
+    # Limit to Linux systems. We don't support Darwin right now.
+    systems.url = "github:nix-systems/default-linux";
+    flake-utils.inputs.systems.follows = "systems";
   };
 
   outputs =
@@ -12,23 +16,43 @@
       nixpkgs,
       flake-utils,
       ...
-    }:
+    }@args: let
+      secretsDirectory = "/run/substituteVars";
+    in
     flake-utils.lib.eachDefaultSystem (
       system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-        substituteVars = import ./lib/substituteVars.nix { inherit pkgs; };
+        substituteVars = import ./lib/substituteVars.nix {
+          inherit secretsDirectory;
+          lib = nixpkgs.lib;
+          runCommand = pkgs.runCommand;
+        };
+
+        module = import ./service.nix ({
+          inherit pkgs secretsDirectory substituteVars;
+          lib = nixpkgs.lib;
+        } // args);
+
+        tests = import ./tests/test.nix {
+          inherit module pkgs substituteVars;
+        };
       in
       {
+        # Export our service
+        nixosModules.substituteVars = module;
+
         # Export our function
         lib.substituteVars = substituteVars;
 
         # Tests
-        checks = {
-          substitutionTest = import ./tests/test.nix {
-            inherit pkgs substituteVars;
-          };
-        };
+        checks = builtins.mapAttrs (_: v: v) tests;
+        # checks.substitutionTest = tests.substitutionTest;
+
+        apps = builtins.mapAttrs (_: v: {
+          type = "app";
+          program = "${v}";
+        }) tests;
 
         # For flake-check command
         formatter = pkgs.nixfmt-rfc-style;

--- a/lib/substituteVars.nix
+++ b/lib/substituteVars.nix
@@ -1,21 +1,103 @@
-{ pkgs }:
+{
+  lib,
+  runCommand,
+  secretsDirectory
+}:
 
-{ src, substitutions }:
+{
+  src,
+  substitutions ? {},
+  secrets ? {},
+  mode ? "0440",
+  owner ? null,
+  group ? null
+}:
 
 let
-  name = "substituted-${builtins.baseNameOf (toString src)}-${builtins.hashString "sha1" (builtins.toJSON substitutions)}";
+  inherit (lib)
+    concatStringsSep
+    escapeShellArg
+    fileContents
+    hashString
+    attrNames
+    mapAttrsToList
+    optionalString
+    ;
 
-  # Properly escape ${var} as \${var} in sed command
-  sedCommands = pkgs.lib.concatStringsSep "\n" (
-    pkgs.lib.mapAttrsToList (k: v: "sed -i 's|\\$\{" + k + "}|" + v + "|g' \"$out\"") substitutions
-  );
-in
-pkgs.stdenv.mkDerivation {
-  inherit name;
+  # Get contents of secrets as a list of sed replacement commands
+  secretReplacements = mapAttrsToList (
+    key: path: "s|\$\{" + key + "\}|\$(<\\$\{escapeShellArg path\})|g"
+  ) secrets;
 
-  phases = [ "installPhase" ];
-  installPhase = ''
-    cp ${src} $out
-    ${sedCommands}
-  '';
-}
+  # Normal substitutions as sed expressions
+  substitutionReplacements = mapAttrsToList (
+    key: val: "s|\$\{" + key + "\}|" + val + "|g"
+  ) substitutions;
+
+  sedScript = concatStringsSep " \n  " (substitutionReplacements ++ secretReplacements);
+
+  # Calculate a hash of all inputs to use in output file name
+  hashInput = builtins.toJSON {
+    srcName = builtins.baseNameOf (toString src);
+    substitutions = substitutions;
+    secrets = mapAttrsToList (_: path: builtins.hashFile "sha256" path) secrets;
+    mode = mode;
+    owner = owner;
+    group = group;
+  };
+  hash = builtins.hashString "sha256" hashInput;
+  outFileName = "${lib.substring 0 8 hash}-${lib.strings.removeSuffix ".in" (builtins.baseNameOf (toString src))}";
+
+in runCommand outFileName {
+  inherit secretsDirectory sedScript;
+  nativeBuildInputs = [ ];
+  passAsFile = [ "sedScript" ]; # pass sedScript as a file, keeps secrets (and secrets file paths) out of the Nix store
+} ''
+  dstfile=$secretsDirectory/${outFileName}
+  echo "$(ls -lah $secretsDirectory)"
+  echo "Dst file"
+  echo "$dstfile"
+  sed -f "$sedScriptPath" "${escapeShellArg (toString src)}" > "$dstfile"
+  ${optionalString (owner != null || group != null) ''
+    chown ${if owner != null then owner else ""}${if owner != null && group != null then ":" else ""}${if group != null then group else ""} "$dstfile"
+  ''}
+  chmod ${mode} "$dstfile"
+  ln -s "$dstfile" "$out"
+''
+
+
+# { pkgs }:
+
+# { src, substitutions, mode ? "0644", owner ? null, group ? null }:
+
+# let
+#   name = "substituted-${builtins.baseNameOf (toString src)}-${builtins.hashString "sha1" (builtins.toJSON substitutions)}";
+
+#   # Properly escape ${var} as \${var} in sed command
+#   sedCommands = pkgs.lib.concatStringsSep "\n" (
+#     pkgs.lib.mapAttrsToList (k: v: "sed -i 's|\\$\{" + k + "}|" + v + "|g' \"$out\"") substitutions
+#   );
+
+#   installFlags =
+#     "-m ${mode}"
+#     + (if owner != null then " -o ${owner}" else "")
+#     + (if group != null then " -g ${group}" else "");
+
+#   fallbackMode = if mode != null then "chmod ${mode} $out" else "";
+
+# in
+
+# pkgs.stdenv.mkDerivation {
+#   inherit name;
+
+#   phases = [ "installPhase" ];
+#   installPhase = ''
+#     echo "fallback mode: ${fallbackMode}"
+#     install ${installFlags} ${src} $out || (
+#       echo "⚠️  'install' failed; falling back to 'cp' and chmod"
+#       cp ${src} $out
+#       ${fallbackMode}
+#     )
+#     ${sedCommands}
+#   '';
+# }

--- a/service.nix
+++ b/service.nix
@@ -1,0 +1,30 @@
+{ lib, pkgs, secretsDirectory, substituteVars, ... }:
+
+with lib;
+
+{
+  config = {
+    # Create the secrets directory as an activation script. We can't do it later
+    # as we won't be running as root.
+    system.activationScripts.agenixNewGeneration = {
+      text = ''
+        echo "Running activation script"
+
+        # Delete the old secrets. We'll recreate them if they're still valid.
+        rm -rf "${secretsDirectory}"
+
+        mkdir -p "${secretsDirectory}
+        chmod 0751 "${secretsDirectory}"
+
+        # Create a RAM disk to ensure the secrets don't survive a reboot and aren't
+        # available to someone sniffing the hard drive.
+        # If the substituteVars module is still included then we'll recreate them.
+        grep -q "${secretsDirectory} ramfs" /proc/mounts ||
+          mount -t ramfs none "${secretsDirectory}" -o nodev,nosuid,mode=0751
+      '';
+      deps = [
+        "specialfs"
+      ];
+    };
+  };
+}


### PR DESCRIPTION
This adds the ability to specify a `secrets` attribute set, where each key is the name of a variable (specified by `${var}`), and the value is the path to a file which contains the value to use to replace that variable.

It also allows specifying the mode, owner, and group for the resulting file.

Secrets are never revealed in the Nix store.